### PR TITLE
Scripts: Fix a stupid typo in the MTK branch (DISK already contains `/dev/`)

### DIFF
--- a/scripts/end-usbms.sh
+++ b/scripts/end-usbms.sh
@@ -60,7 +60,7 @@ mtk_usb() {
 	# Common
 	mkdir -p /sys/kernel/config/usb_gadget/g1
 	mkdir -p /sys/kernel/config/usb_gadget/g1/strings/0x409
-	PARTITION="/dev/${DISK}0p12"
+	PARTITION="${DISK}0p12"
 
 	# Remove
 	echo "" > /sys/kernel/config/usb_gadget/g1/UDC

--- a/scripts/start-usbms.sh
+++ b/scripts/start-usbms.sh
@@ -112,7 +112,7 @@ mtk_usb() {
 	# Common (create a gadget template named g1, and allow us to setup the required English strings)
 	mkdir -p /sys/kernel/config/usb_gadget/g1
 	mkdir -p /sys/kernel/config/usb_gadget/g1/strings/0x409
-	PARTITION="/dev/${DISK}0p12"
+	PARTITION="${DISK}0p12"
 
 	# Fill out vID/pID & said English strings
 	echo "${USB_VENDOR_ID}"      > /sys/kernel/config/usb_gadget/g1/idVendor


### PR DESCRIPTION
A fix based on the log posted in [this comment](https://github.com/koreader/koreader/pull/11737#issuecomment-2088415917).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/KoboUSBMS/3)
<!-- Reviewable:end -->
