### PR TITLE
improve reproducibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ kobo: armcheck release
 	ln -sf $(CURDIR)/resources/fonts/CaskaydiaCove_NF.ttf Kobo/resources/fonts/CaskaydiaCove_NF.ttf
 	ln -sf $(CURDIR)/$(OUT_DIR)/usbms Kobo/usbms
 	ln -sf $(CURDIR)/l10n Kobo/l10n
-	tar --mtime=@$(USBMS_EPOCH) --owner=root --group=root -cvzhf $(OUT_DIR)/KoboUSBMS.tar.gz -C Kobo .
+	tar --mtime=@$(USBMS_EPOCH) --owner=root --group=root --sort=name -cvzhf $(OUT_DIR)/KoboUSBMS.tar.gz -C Kobo .
 
 pot:
 	mkdir -p po/templates


### PR DESCRIPTION
Ensure the TAR file records are always in the same order.