### PR TITLE
Support newer v5 nickel usb gadget name kobo

### DIFF
--- a/scripts/end-usbms.sh
+++ b/scripts/end-usbms.sh
@@ -86,6 +86,7 @@ mtk_usb() {
 	rmdir "/sys/kernel/config/usb_gadget/${GADGET_NAME}"
 
 	# Modern Kobo V5 Firmware has this init script which preconfigures the usb gadget for usb mass storage so nickel USB works again.
+	# Nickel expects the usb gadget to be set up, otherwise mass storage does not work, that's why we call the init script here.
 	# The init script _always_ checks for existance of the kobo usb gadget and creates/configures it if not existing, no parameters needed.
 	if [ -e "/etc/init.d/usb-gadget" ]; then
 	  /etc/init.d/usb-gadget

--- a/scripts/end-usbms.sh
+++ b/scripts/end-usbms.sh
@@ -57,27 +57,33 @@ legacy_usb() {
 
 # MTK SoCs, via configfs
 mtk_usb() {
+	# Modern Kobo V5 Firmware uses usb_gadget name kobo, older V5 and v4 uses g1
+	if [ -e /etc/init.d/usb-gadget ]; then
+	  GADGET_NAME=kobo
+	else
+	  GADGET_NAME=g1
+	fi
 	# If we're NOT in the middle of an USBMS session, something went wrong...
-	if [ "$(cat /sys/kernel/config/usb_gadget/g1/UDC)" != "11211000.usb" ] ; then
+	if [ "$(cat /sys/kernel/config/usb_gadget/$GADGET_NAME/UDC)" != "11211000.usb" ] ; then
 		logger -p "DAEMON.ERR" -t "${SCRIPT_NAME}[$$]" "Not in an USBMS session?!"
 		exit 1
 	fi
 
 	# Disable the gadget
-	echo "" > /sys/kernel/config/usb_gadget/g1/UDC
+	echo "" > /sys/kernel/config/usb_gadget/$GADGET_NAME/UDC
 
 	# Unbind function from config
-	rm /sys/kernel/config/usb_gadget/g1/configs/c.1/mass_storage.0
+	rm /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/mass_storage.0
 	# Remove the config's strings
-	rmdir /sys/kernel/config/usb_gadget/g1/configs/c.1/strings/0x409
+	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/strings/0x409
 	# Remove the config
-	rmdir /sys/kernel/config/usb_gadget/g1/configs/c.1
+	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1
 	# Remove the function
-	rmdir /sys/kernel/config/usb_gadget/g1/functions/mass_storage.0
+	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0
 	# Remove the gadget's strings
-	rmdir /sys/kernel/config/usb_gadget/g1/strings/0x409
+	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409
 	# And remove the gadget
-	rmdir /sys/kernel/config/usb_gadget/g1
+	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME
 
 	PARTITION="${DISK}0p12"
 }

--- a/scripts/end-usbms.sh
+++ b/scripts/end-usbms.sh
@@ -58,36 +58,36 @@ legacy_usb() {
 # MTK SoCs, via configfs
 mtk_usb() {
 	# Modern Kobo V5 Firmware uses usb_gadget name kobo, older V5 and v4 uses g1
-	if [ -e /etc/init.d/usb-gadget ]; then
+	if [ -e "/etc/init.d/usb-gadget" ]; then
 	  GADGET_NAME=kobo
 	else
 	  GADGET_NAME=g1
 	fi
 	# If we're NOT in the middle of an USBMS session, something went wrong...
-	if [ "$(cat /sys/kernel/config/usb_gadget/$GADGET_NAME/UDC)" != "11211000.usb" ] ; then
+	if [ "$(cat /sys/kernel/config/usb_gadget/${GADGET_NAME}/UDC)" != "11211000.usb" ] ; then
 		logger -p "DAEMON.ERR" -t "${SCRIPT_NAME}[$$]" "Not in an USBMS session?!"
 		exit 1
 	fi
 
 	# Disable the gadget
-	echo "" > /sys/kernel/config/usb_gadget/$GADGET_NAME/UDC
+	echo "" > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/UDC"
 
 	# Unbind function from config
-	rm /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/mass_storage.0
+	rm "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1/mass_storage.0"
 	# Remove the config's strings
-	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/strings/0x409
+	rmdir "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1/strings/0x409"
 	# Remove the config
-	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1
+	rmdir "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1"
 	# Remove the function
-	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0
+	rmdir "/sys/kernel/config/usb_gadget/${GADGET_NAME}/functions/mass_storage.0"
 	# Remove the gadget's strings
-	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409
+	rmdir "/sys/kernel/config/usb_gadget/${GADGET_NAME}/strings/0x409"
 	# And remove the gadget
-	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME
+	rmdir "/sys/kernel/config/usb_gadget/${GADGET_NAME}"
 
 	# Modern Kobo V5 Firmware has this init script which preconfigures the usb gadget for usb mass storage so nickel USB works again.
 	# The init script _always_ checks for existance of the kobo usb gadget and creates/configures it if not existing, no parameters needed.
-	if [ -e /etc/init.d/usb-gadget ]; then
+	if [ -e "/etc/init.d/usb-gadget" ]; then
 	  /etc/init.d/usb-gadget
 	fi
 

--- a/scripts/end-usbms.sh
+++ b/scripts/end-usbms.sh
@@ -85,7 +85,8 @@ mtk_usb() {
 	# And remove the gadget
 	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME
 
-	# Modern Kobo V5 Firmware has this init script which preconfigures the usb gadget for usb mass storage so nickel USB works again
+	# Modern Kobo V5 Firmware has this init script which preconfigures the usb gadget for usb mass storage so nickel USB works again.
+	# The init script _always_ checks for existance of the kobo usb gadget and creates/configures it if not existing, no parameters needed.
 	if [ -e /etc/init.d/usb-gadget ]; then
 	  /etc/init.d/usb-gadget
 	fi

--- a/scripts/end-usbms.sh
+++ b/scripts/end-usbms.sh
@@ -85,6 +85,11 @@ mtk_usb() {
 	# And remove the gadget
 	rmdir /sys/kernel/config/usb_gadget/$GADGET_NAME
 
+	# Modern Kobo V5 Firmware has this init script which preconfigures the usb gadget for usb mass storage so nickel USB works again
+	if [ -e /etc/init.d/usb-gadget ]; then
+	  /etc/init.d/usb-gadget
+	fi
+
 	PARTITION="${DISK}0p12"
 }
 

--- a/scripts/start-usbms.sh
+++ b/scripts/start-usbms.sh
@@ -109,31 +109,37 @@ legacy_usb() {
 # MTK SoCs, via configfs
 # c.f., https://elinux.org/images/e/ef/USB_Gadget_Configfs_API_0.pdf & https://docs.kernel.org/usb/gadget_configfs.html
 mtk_usb() {
-	# Common (create a gadget template named g1 (same name as Nickel's), and allow us to setup the required English strings)
-	mkdir -p /sys/kernel/config/usb_gadget/g1
-	mkdir -p /sys/kernel/config/usb_gadget/g1/strings/0x409
+	# Modern Kobo V5 Firmware uses usb_gadget name kobo, older V5 and v4 uses g1
+	if [ -e /etc/init.d/usb-gadget ]; then
+	  GADGET_NAME=kobo
+	else
+	  GADGET_NAME=g1
+	fi
+	# Common (create a gadget template named same name as Nickel's, and allow us to setup the required English strings)
+	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME
+	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409
 	PARTITION="${DISK}0p12"
 
 	# Fill out vID/pID & said English strings
-	echo "${USB_VENDOR_ID}"      > /sys/kernel/config/usb_gadget/g1/idVendor
-	echo "${USB_PRODUCT_ID}"     > /sys/kernel/config/usb_gadget/g1/idProduct
-	echo "${SERIAL_NUMBER}"      > /sys/kernel/config/usb_gadget/g1/strings/0x409/serialnumber
-	echo "Kobo"                  > /sys/kernel/config/usb_gadget/g1/strings/0x409/manufacturer
-	echo "eReader-${FW_VERSION}" > /sys/kernel/config/usb_gadget/g1/strings/0x409/product
+	echo "${USB_VENDOR_ID}"      > /sys/kernel/config/usb_gadget/$GADGET_NAME/idVendor
+	echo "${USB_PRODUCT_ID}"     > /sys/kernel/config/usb_gadget/$GADGET_NAME/idProduct
+	echo "${SERIAL_NUMBER}"      > /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409/serialnumber
+	echo "Kobo"                  > /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409/manufacturer
+	echo "eReader-${FW_VERSION}" > /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409/product
 	# Setup a configuration instance & its description
-	mkdir -p /sys/kernel/config/usb_gadget/g1/configs/c.1/strings/0x409
-	echo "KOBOeReader"           > /sys/kernel/config/usb_gadget/g1/configs/c.1/strings/0x409/configuration
+	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/strings/0x409
+	echo "KOBOeReader"           > /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/strings/0x409/configuration
 
 	# Setup a mass storage function instance
-	mkdir -p /sys/kernel/config/usb_gadget/g1/functions/mass_storage.0/lun.0
-	echo "${PARTITION}" > /sys/kernel/config/usb_gadget/g1/functions/mass_storage.0/lun.0/file
+	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0/lun.0
+	echo "${PARTITION}" > /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0/lun.0/file
 	# Bind function to config
 	# NOTE: Nickel never cleans up its own USBMS gadget, and we don't want to force an unlink, so make this conditional...
-	if [ ! -L "/sys/kernel/config/usb_gadget/g1/configs/c.1/mass_storage.0" ] ; then
-		ln -s /sys/kernel/config/usb_gadget/g1/functions/mass_storage.0 /sys/kernel/config/usb_gadget/g1/configs/c.1
+	if [ ! -L "/sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/mass_storage.0" ] ; then
+		ln -s /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0 /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1
 	fi
 	# Attach our new gadget device to the right USB Device Controller (c.f., /sys/class/udc)
-	echo "11211000.usb" > /sys/kernel/config/usb_gadget/g1/UDC
+	echo "11211000.usb" > /sys/kernel/config/usb_gadget/$GADGET_NAME/UDC
 }
 
 case "${PLATFORM}" in

--- a/scripts/start-usbms.sh
+++ b/scripts/start-usbms.sh
@@ -110,36 +110,36 @@ legacy_usb() {
 # c.f., https://elinux.org/images/e/ef/USB_Gadget_Configfs_API_0.pdf & https://docs.kernel.org/usb/gadget_configfs.html
 mtk_usb() {
 	# Modern Kobo V5 Firmware uses usb_gadget name kobo, older V5 and v4 uses g1
-	if [ -e /etc/init.d/usb-gadget ]; then
+	if [ -e "/etc/init.d/usb-gadget" ]; then
 	  GADGET_NAME=kobo
 	else
 	  GADGET_NAME=g1
 	fi
 	# Common (create a gadget template named same name as Nickel's, and allow us to setup the required English strings)
-	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME
-	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409
+	mkdir -p "/sys/kernel/config/usb_gadget/${GADGET_NAME}"
+	mkdir -p "/sys/kernel/config/usb_gadget/${GADGET_NAME}/strings/0x409"
 	PARTITION="${DISK}0p12"
 
 	# Fill out vID/pID & said English strings
-	echo "${USB_VENDOR_ID}"      > /sys/kernel/config/usb_gadget/$GADGET_NAME/idVendor
-	echo "${USB_PRODUCT_ID}"     > /sys/kernel/config/usb_gadget/$GADGET_NAME/idProduct
-	echo "${SERIAL_NUMBER}"      > /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409/serialnumber
-	echo "Kobo"                  > /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409/manufacturer
-	echo "eReader-${FW_VERSION}" > /sys/kernel/config/usb_gadget/$GADGET_NAME/strings/0x409/product
+	echo "${USB_VENDOR_ID}"      > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/idVendor"
+	echo "${USB_PRODUCT_ID}"     > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/idProduct"
+	echo "${SERIAL_NUMBER}"      > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/strings/0x409/serialnumber"
+	echo "Kobo"                  > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/strings/0x409/manufacturer"
+	echo "eReader-${FW_VERSION}" > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/strings/0x409/product"
 	# Setup a configuration instance & its description
-	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/strings/0x409
-	echo "KOBOeReader"           > /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/strings/0x409/configuration
+	mkdir -p "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1/strings/0x409"
+	echo "KOBOeReader"           > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1/strings/0x409/configuration"
 
 	# Setup a mass storage function instance
-	mkdir -p /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0/lun.0
-	echo "${PARTITION}" > /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0/lun.0/file
+	mkdir -p "/sys/kernel/config/usb_gadget/${GADGET_NAME}/functions/mass_storage.0/lun.0"
+	echo "${PARTITION}" > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/functions/mass_storage.0/lun.0/file"
 	# Bind function to config
 	# NOTE: Nickel never cleans up its own USBMS gadget, and we don't want to force an unlink, so make this conditional...
-	if [ ! -L "/sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1/mass_storage.0" ] ; then
-		ln -s /sys/kernel/config/usb_gadget/$GADGET_NAME/functions/mass_storage.0 /sys/kernel/config/usb_gadget/$GADGET_NAME/configs/c.1
+	if [ ! -L "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1/mass_storage.0" ] ; then
+		ln -s "/sys/kernel/config/usb_gadget/${GADGET_NAME}/functions/mass_storage.0" "/sys/kernel/config/usb_gadget/${GADGET_NAME}/configs/c.1"
 	fi
 	# Attach our new gadget device to the right USB Device Controller (c.f., /sys/class/udc)
-	echo "11211000.usb" > /sys/kernel/config/usb_gadget/$GADGET_NAME/UDC
+	echo "11211000.usb" > "/sys/kernel/config/usb_gadget/${GADGET_NAME}/UDC"
 }
 
 case "${PLATFORM}" in

--- a/usbms.c
+++ b/usbms.c
@@ -1413,6 +1413,7 @@ int
 	// And now, on to the fun stuff!
 	bool need_early_abort = false;
 	bool early_unmount    = false;
+	bool had_swap         = false;
 	// If we're in USBNet mode, abort!
 	// (tearing it down properly is out of our scope, since we can't really know how the user enabled it in the first place).
 	if (is_module_loaded("g_ether ")) {
@@ -1521,6 +1522,36 @@ int
 		if (mount_points[i].id != PARTITION_INTERNAL && access(mount_points[i].device, F_OK) != 0) {
 			LOG(LOG_INFO, "%s storage device not available.", mount_points[i].name);
 			continue;
+		}
+
+		// Check if any swap is active on this mountpoint, because it'd make our umount2 test fail…
+		if (!had_swap) {
+			FILE* swaps = fopen("/proc/swaps", "re");
+			if (swaps) {
+				char swap_line[PATH_MAX];
+				// Skip header line
+				if (fgets(swap_line, sizeof(swap_line), swaps)) {
+					const size_t mp_len = strlen(mount_points[i].mountpoint);
+					while (fgets(swap_line, sizeof(swap_line), swaps)) {
+						if (strncmp(swap_line,
+						            mount_points[i].mountpoint,
+						            mp_len) == 0) {
+							LOG(LOG_INFO,
+							    "Swap is active on %s storage, disabling…",
+							    mount_points[i].name);
+							had_swap = true;
+							break;
+						}
+					}
+				}
+				fclose(swaps);
+				if (had_swap) {
+					rc = system("swapoff -a");
+					if (rc != EXIT_SUCCESS) {
+						LOG(LOG_WARNING, "Failed to disable swap (rc: %d)!", rc);
+					}
+				}
+			}
 		}
 
 		// Wee bit of trickery with an obscure umount2 feature, to see if the mountpoint is currently busy,
@@ -2278,6 +2309,15 @@ int
 
 		rv = EXIT_FAILURE;
 		goto cleanup;
+	}
+
+	// Restore swap if we had disabled it earlier
+	if (had_swap) {
+		LOG(LOG_INFO, "Re-enabling swap…");
+		rc = system("swapon -a");
+		if (rc != EXIT_SUCCESS) {
+			LOG(LOG_WARNING, "Failed to re-enable swap (rc: %d)!", rc);
+		}
 	}
 
 	// Handle date/time synchronization, like Nickel

--- a/usbms.h
+++ b/usbms.h
@@ -204,6 +204,7 @@ typedef struct
 
 // For the "checking for custom usb gadget" scandir
 #define DEFAULT_NICKEL_USB_GADGET "g1"
+#define DEFAULT_NICKEL_USB_GADGET2 "kobo"
 static int
     is_custom_gadget(const struct dirent* dir)
 {
@@ -216,7 +217,7 @@ static int
 	if (dir->d_name[0] == '.') {
 		return 0;
 	} else {
-		return strcmp(DEFAULT_NICKEL_USB_GADGET, dir->d_name) != 0;
+		return (strcmp(DEFAULT_NICKEL_USB_GADGET, dir->d_name) != 0) && (strcmp(DEFAULT_NICKEL_USB_GADGET2, dir->d_name) != 0);
 	}
 }
 


### PR DESCRIPTION
More recent v5 firmware renamed the usb_gadget from `g1` to `kobo`. accept this in USBMS.

- [x] handle new usb_gadget handling for nickel support
- [x] handle swapfile on `/mnt/onboard`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/KoboUSBMS/7)
<!-- Reviewable:end -->
