### PR TITLE
Add support for P365 variant of Kobo Clara BW

### DIFF
--- a/usbms.c
+++ b/usbms.c
@@ -138,6 +138,7 @@ static void
 			pid = 0x5237;
 			break;
 		case DEVICE_KOBO_CLARA_BW:          // Kobo Clara B&W (spa)
+		case DEVICE_KOBO_CLARA_BW_TPV:
 			pid = 0x4239;
 			break;
 		case DEVICE_TOLINO_SHINE_BW:        // Tolino Shine B&W (spa)


### PR DESCRIPTION
Fixes #9 

After this Calibre correctly detect P365:
```calibre 9.11  embedded-python: True
macOS-26.5.1-arm64-arm-64bit-Mach-O Darwin ('64bit', 'Mach-O')
('Darwin', '25.5.0', 'Darwin Kernel Version 25.5.0: Mon Apr 27 20:39:09 PDT 2026; root:xnu-12377.121.6~2/RELEASE_ARM64_T6020')
Python 3.14.6
OSX: ('26.5.1', ('', '', ''), 'arm64')
Interface language: ru
EXE path: /Applications/calibre.app/Contents/MacOS/calibre
Successfully initialized third party plugins: DeACSM (0, 0, 16) && Gather KFX-ZIP (from KFX Input) (2, 33, 0) && DeDRM (10, 0, 9) && Package KFX (from KFX Input) (2, 33, 0) && CBZ Output (0, 0, 1) && Count Pages (1, 15, 2) && Find Duplicates (1, 10, 10) && KFX metadata reader (from KFX Input) (2, 33, 0) && From KFX (2, 33, 0) && KFX Input (2, 33, 0) && Kobo Utilities (2, 28, 1) && NoTrans (3, 1, 0) && Obok DeDRM (10, 0, 9)
USB devices on system:
[['0x2237', '0x4239', '0x409', 'Kobo', 'eReader-4.45.23697', 'P3655C2009049']]

No disabled plugins
Looking for devices of type: MTP_DEVICE
No MTP devices connected to system
 
Looking for devices of type: SMART_DEVICE_APP
All IP addresses {'lo0': [{'addr': '127.0.0.1', 'netmask': '255.0.0.0', 'peer': '127.0.0.1'}], 'en0': [{'addr': '192.168.1.224', 'netmask': '255.255.255.0', 'broadcast': '192.168.1.255'}]}
No device is connected
 
Looking for devices...
USBDevice(busnum=2, devnum=1, vendor_id=0x2237, product_id=0x4239, bcd=0x0409, manufacturer=Kobo, product=eReader-4.45.23697, serial=P3655C2009049)
		Detected possible device KOBOTOUCH
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/koreader/KoboUSBMS/10)
<!-- Reviewable:end -->
